### PR TITLE
Use string.Length instead of comparison with empty string

### DIFF
--- a/src/EcoCode.Core/Analyzers/EC92.UseStringEmptyLength.Fixer.cs
+++ b/src/EcoCode.Core/Analyzers/EC92.UseStringEmptyLength.Fixer.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.CodeAnalysis.Formatting;
+
+namespace EcoCode.Analyzers;
+
+/// <summary>EC92 fixer: Use string.Length instead of comparison with empty string</summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseStringLengthCodeFixProvider)), Shared]
+public class UseStringLengthCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => _fixableDiagnosticIds;
+    private static readonly ImmutableArray<string> _fixableDiagnosticIds = [UseStringEmptyLength.Descriptor.Id];
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics[0];
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        // Find the node at the diagnostic location.
+        var node = root.FindNode(diagnosticSpan);
+
+        // Register a code action that will invoke the fix.
+        context.RegisterCodeFix(
+            Microsoft.CodeAnalysis.CodeActions.CodeAction.Create(
+                title: "Use string.Length instead of comparison with empty string",
+                createChangedDocument: c => ReplaceWithLengthCheckAsync(context.Document, node, c),
+                equivalenceKey: "Use string.Length instead of comparison with empty string"),
+            diagnostic);
+    }
+
+    private async Task<Document> ReplaceWithLengthCheckAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        if (node is BinaryExpressionSyntax binaryExpression)
+        {
+            var newExpression = CreateLengthCheckExpression(binaryExpression, semanticModel);
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var newRoot = root.ReplaceNode(binaryExpression, newExpression);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        return document;
+    }
+
+    private ExpressionSyntax CreateLengthCheckExpression(BinaryExpressionSyntax binaryExpression, SemanticModel semanticModel)
+    {
+        var left = binaryExpression.Left;
+        var right = binaryExpression.Right;
+
+        ExpressionSyntax stringExpression = null;
+
+        // Determine which side is the string literal and which is the string variable.
+        if (IsEmptyString(left))
+        {
+            stringExpression = right;
+        }
+        else if (IsEmptyString(right))
+        {
+            stringExpression = left;
+        }
+
+        if (stringExpression == null)
+        {
+            return binaryExpression; // Return the original expression if we can't determine the string expression.
+        }
+
+        // Create the new expression: stringExpression.Length == 0 or stringExpression.Length != 0
+        var lengthMemberAccess = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            stringExpression,
+            SyntaxFactory.IdentifierName("Length"));
+
+        var zeroLiteral = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(0));
+
+        var newBinaryExpression = binaryExpression.Kind() == SyntaxKind.EqualsExpression
+            ? SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, lengthMemberAccess, zeroLiteral)
+            : SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, lengthMemberAccess, zeroLiteral);
+
+        return newBinaryExpression
+            .WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
+    }
+
+    private static bool IsEmptyString(ExpressionSyntax expression)
+    {
+        return expression is LiteralExpressionSyntax literal && literal.Token.ValueText.Length == 0;
+    }
+}
+

--- a/src/EcoCode.Core/Analyzers/EC92.UseStringEmptyLength.cs
+++ b/src/EcoCode.Core/Analyzers/EC92.UseStringEmptyLength.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
-
-namespace EcoCode.Analyzers;
+﻿namespace EcoCode.Analyzers;
 
 /// <summary>EC92: Use string.Length instead of comparison with empty string</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/EcoCode.Core/Analyzers/EC92.UseStringEmptyLength.cs
+++ b/src/EcoCode.Core/Analyzers/EC92.UseStringEmptyLength.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+
+namespace EcoCode.Analyzers;
+
+/// <summary>EC92: Use string.Length instead of comparison with empty string</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseStringEmptyLength : DiagnosticAnalyzer
+{
+    private static readonly ImmutableArray<SyntaxKind> EqualsExpression = [SyntaxKind.EqualsExpression];
+    private static readonly ImmutableArray<SyntaxKind> NotEqualsExpression = [SyntaxKind.NotEqualsExpression];
+
+    /// <summary>The diagnostic descriptor.</summary>
+    public static DiagnosticDescriptor Descriptor { get; } = Rule.CreateDescriptor(
+                id: Rule.Ids.EC92_UseStringEmptyLength,
+                title: "Use string.Length instead of comparison with empty string",
+                message: "Use string.Length instead of comparison with empty string",
+                category: Rule.Categories.Usage,
+                severity: DiagnosticSeverity.Warning,
+                description: "Use string.Length instead of comparison with empty string for better readability and performance.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
+    private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics = [Descriptor];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterSyntaxNodeAction(AnalyzeComparison, EqualsExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeComparison, NotEqualsExpression);
+    }
+
+    private static void AnalyzeComparison(SyntaxNodeAnalysisContext context)
+    {
+        var binaryExpression = (BinaryExpressionSyntax)context.Node;
+
+        // Check if either side of the comparison is a string literal ""
+        if (IsEmptyStringComparison(binaryExpression, context.SemanticModel))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, binaryExpression.GetLocation()));
+        }
+    }
+
+    private static bool IsEmptyStringComparison(BinaryExpressionSyntax binaryExpression, SemanticModel semanticModel)
+    {
+        // Check if the left or right side of the expression is an empty string literal
+        var left = binaryExpression.Left;
+        var right = binaryExpression.Right;
+
+        return (IsStringLiteral(left, semanticModel) && IsEmptyString(right)) ||
+               (IsStringLiteral(right, semanticModel) && IsEmptyString(left));
+    }
+
+    private static bool IsStringLiteral(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        var typeInfo = semanticModel.GetTypeInfo(expression);
+        return typeInfo.Type?.SpecialType == SpecialType.System_String;
+    }
+
+    private static bool IsEmptyString(ExpressionSyntax expression)
+    {
+        return expression is LiteralExpressionSyntax literal && literal.Token.ValueText.Length == 0;
+    }
+}

--- a/src/EcoCode.Core/Models/Rule.cs
+++ b/src/EcoCode.Core/Models/Rule.cs
@@ -23,6 +23,7 @@ internal static class Rule
         public const string EC87_UseCollectionIndexer = "EC87";
         public const string EC88_DisposeResourceAsynchronously = "EC88";
         public const string EC89_DoNotPassMutableStructAsRefReadonly = "EC89";
+        public const string EC92_UseStringEmptyLength = "EC92";
     }
 
     /// <summary>Creates a diagnostic descriptor.</summary>

--- a/src/EcoCode.Tests/Tests/EC92.UseStringsEmptyLength.Tests.cs
+++ b/src/EcoCode.Tests/Tests/EC92.UseStringsEmptyLength.Tests.cs
@@ -1,15 +1,13 @@
-﻿using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis;
-
-namespace EcoCode.Tests;
+﻿namespace EcoCode.Tests;
 
 [TestClass]
 public sealed class UseStringEmptyLengthTests
 {
-    private static readonly AnalyzerDlg VerifyAsync = TestRunner.VerifyAsync<UseStringEmptyLength>;
-    
+    private static readonly CodeFixerDlg VerifyAsync = TestRunner.VerifyAsync<UseStringEmptyLength, UseStringLengthCodeFixProvider>;
+
+    #region Analyzer
     [TestMethod]
-    public async Task EmptyCodeAsync() => await VerifyAsync("").ConfigureAwait(false);
+    public Task EmptyCodeAsync() =>  VerifyAsync("");
 
     [TestMethod]
     public Task DontUseStringEmptyLengthWithEqualsExpressionAsync() => VerifyAsync("""
@@ -58,4 +56,73 @@ public sealed class UseStringEmptyLengthTests
             }
         }
         """);
+    #endregion
+
+    #region CodeFixer
+
+    [TestMethod]
+    public Task FixDontUseStringEmptyLengthWithEqualsExpressionAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if ([|test == ""|]) { }
+            }
+        }
+        """, """
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if (test.Length == 0) { }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task FixDontUseStringEmptyLengthReverseWithEqualsExpressionAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if ([|"" == test|]) { }
+            }
+        }
+        """, """
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if (test.Length == 0) { }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task FixDontUseStringEmptyLengthWithNotEqualsExpressionAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if ([|test != ""|]) { }
+            }
+        }
+        """, """
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if (test.Length != 0) { }
+            }
+        }
+        """);
+
+    #endregion
+
 }

--- a/src/EcoCode.Tests/Tests/EC92.UseStringsEmptyLength.Tests.cs
+++ b/src/EcoCode.Tests/Tests/EC92.UseStringsEmptyLength.Tests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace EcoCode.Tests;
+
+[TestClass]
+public sealed class UseStringEmptyLengthTests
+{
+    private static readonly AnalyzerDlg VerifyAsync = TestRunner.VerifyAsync<UseStringEmptyLength>;
+    
+    [TestMethod]
+    public async Task EmptyCodeAsync() => await VerifyAsync("").ConfigureAwait(false);
+
+    [TestMethod]
+    public Task DontUseStringEmptyLengthWithEqualsExpressionAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if ([|test == ""|]) { }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task DontUseStringEmptyLengthReverseWithEqualsExpressionAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if ([|"" == test|]) { }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task DontUseStringEmptyLengthWithNotEqualsExpressionAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if ([|"" != test|]) { }
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task UseStringEmptyLengthAsync() => VerifyAsync("""
+        class TestClass
+        {
+            void TestMethod()
+            {
+                string test = "test";
+                if (test.Length == 0) { }
+            }
+        }
+        """);
+}


### PR DESCRIPTION
## [UseStringEmptyLength] - 30-05-2024

###Added
- Analizer
- CodeFixer
- Unit Test
- Rule tag