### PR TITLE
UseRegexInstanceInsteadOfStaticMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Creedengo C# can use [SonarScanner for .Net](https://docs.sonarsource.com/sonarq
 |[GCI92](https://github.com/green-code-initiative/creedengo-rules-specifications/blob/main/src/main/rules/GCI92/csharp/GCI92.asciidoc)|Use `Length` to test empty `strings`|⚠️|✔️|
 |[GCI93](https://github.com/green-code-initiative/creedengo-rules-specifications/blob/main/src/main/rules/GCI93/csharp/GCI93.asciidoc)|Return `Task` directly|ℹ️|✔️|
 |[GCI95](https://github.com/green-code-initiative/creedengo-rules-specifications/blob/main/src/main/rules/GCI95/csharp/GCI95.asciidoc)|Use `is` operator instead of `as` operator|ℹ️|✔️|
+|[GCI97](https://github.com/green-code-initiative/creedengo-rules-specifications/blob/main/src/main/rules/GCI97/csharp/GCI97.asciidoc)|Use `Regex` instance instead of static method|⚠️|✔️|
 
 🌿 Customized Roslyn Rules
 -------------------

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
@@ -1,0 +1,102 @@
+namespace Creedengo.Core.Analyzers;
+
+/// <summary>GCI97 fixer: Use Regex instance instead of static method.</summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseRegexInstanceInsteadOfStaticMethodFixer)), Shared]
+public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => _fixableDiagnosticIds;
+    private static readonly ImmutableArray<string> _fixableDiagnosticIds = ImmutableArray.Create(UseRegexInstanceInsteadOfStaticMethod.Descriptor.Id);
+
+    /// <inheritdoc/>
+    [ExcludeFromCodeCoverage]
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (context.Diagnostics.Length == 0) return;
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var node = root.FindNode(context.Span, getInnermostNodeForTie: true);
+        if (node is not InvocationExpressionSyntax) return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Use Regex instance",
+                createChangedDocument: token => RefactorAsync(context.Document, node, token),
+                equivalenceKey: "Use Regex instance"),
+            context.Diagnostics);
+    }
+
+    private static async Task<Document> RefactorAsync(Document document, SyntaxNode node, CancellationToken token)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, token).ConfigureAwait(false);
+        if (node is not InvocationExpressionSyntax invocation) return document;
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
+
+        var methodName = memberAccess.Name.Identifier.Text;
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count < 2) return document;
+
+        // First arg is input, second is pattern for static Regex methods
+        var inputArg = args[0];
+        var patternArg = args[1];
+
+        // Build remaining args (skip input and pattern, e.g. RegexOptions)
+        var remainingArgs = new SyntaxList<ArgumentSyntax>();
+        var constructorExtraArgs = new SyntaxList<ArgumentSyntax>();
+        for (int i = 2; i < args.Count; i++)
+        {
+            var argType = editor.SemanticModel.GetTypeInfo(args[i].Expression, token).Type;
+            if (argType is not null && argType.Name == "RegexOptions")
+                constructorExtraArgs = constructorExtraArgs.Add(args[i]);
+            else
+                remainingArgs = remainingArgs.Add(args[i]);
+        }
+
+        // Build constructor arguments: pattern [, options]
+        var constructorArgs = new[] { SyntaxFactory.Argument(patternArg.Expression) }
+            .Concat(constructorExtraArgs.Select(a => SyntaxFactory.Argument(a.Expression)));
+
+        // Create field: private readonly Regex _regex = new Regex(pattern);
+        var fieldDeclaration = SyntaxFactory.FieldDeclaration(
+            SyntaxFactory.VariableDeclaration(
+                SyntaxFactory.IdentifierName("Regex"),
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator("_regex")
+                        .WithInitializer(SyntaxFactory.EqualsValueClause(
+                            SyntaxFactory.ObjectCreationExpression(
+                                SyntaxFactory.IdentifierName("Regex"),
+                                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(constructorArgs)),
+                                null))))))
+            .WithModifiers(SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+                SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)))
+            .NormalizeWhitespace()
+            .WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
+
+        // Replace invocation: _regex.IsMatch(input [, remaining])
+        var instanceArgs = new[] { SyntaxFactory.Argument(inputArg.Expression) }
+            .Concat(remainingArgs.Select(a => SyntaxFactory.Argument(a.Expression)));
+
+        var newInvocation = SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName("_regex"),
+                SyntaxFactory.IdentifierName(methodName)),
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(instanceArgs)));
+
+        editor.ReplaceNode(invocation, newInvocation);
+
+        // Insert field before the containing method
+        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (containingMethod is not null)
+            editor.InsertBefore(containingMethod, fieldDeclaration);
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
@@ -37,6 +37,11 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
         if (node is not InvocationExpressionSyntax invocation) return document;
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
 
+        // Detect EOL style from existing document
+        var eolTrivia = editor.OriginalRoot.DescendantTrivia()
+            .FirstOrDefault(t => t.IsKind(SyntaxKind.EndOfLineTrivia));
+        var eol = eolTrivia != default ? eolTrivia : SyntaxFactory.ElasticLineFeed;
+
         var methodName = memberAccess.Name.Identifier.Text;
         var args = invocation.ArgumentList.Arguments;
         if (args.Count < 2) return document;
@@ -61,6 +66,10 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
         var constructorArgs = new[] { SyntaxFactory.Argument(patternArg.Expression) }
             .Concat(constructorExtraArgs.Select(a => SyntaxFactory.Argument(a.Expression)));
 
+        // Find containing method for indentation and insertion point
+        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (containingMethod is null) return document;
+
         // Create field: private readonly Regex _regex = new Regex(pattern);
         var fieldDeclaration = SyntaxFactory.FieldDeclaration(
             SyntaxFactory.VariableDeclaration(
@@ -76,8 +85,8 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
                 SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
                 SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)))
             .NormalizeWhitespace()
-            .WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
-            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
+            .WithLeadingTrivia(containingMethod.GetLeadingTrivia())
+            .WithTrailingTrivia(eol, eol);
 
         // Replace invocation: _regex.IsMatch(input [, remaining])
         var instanceArgs = new[] { SyntaxFactory.Argument(inputArg.Expression) }
@@ -91,11 +100,7 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
             SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(instanceArgs)));
 
         editor.ReplaceNode(invocation, newInvocation);
-
-        // Insert field before the containing method
-        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod is not null)
-            editor.InsertBefore(containingMethod, fieldDeclaration);
+        editor.InsertBefore(containingMethod, fieldDeclaration);
 
         return editor.GetChangedDocument();
     }

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
@@ -37,24 +37,35 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
         if (node is not InvocationExpressionSyntax invocation) return document;
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
 
-        // Detect EOL style from existing document
-        var eolTrivia = editor.OriginalRoot.DescendantTrivia()
-            .FirstOrDefault(t => t.IsKind(SyntaxKind.EndOfLineTrivia));
-        var eol = eolTrivia != default ? eolTrivia : SyntaxFactory.ElasticLineFeed;
+        var regexTypeSymbol = editor.SemanticModel.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Regex");
+        if (regexTypeSymbol is null) return document;
 
         var methodName = memberAccess.Name.Identifier.Text;
         var args = invocation.ArgumentList.Arguments;
         if (args.Count < 2) return document;
 
-        // First arg is input, second is pattern for static Regex methods
+        // First arg is input, second is pattern for static Regex methods.
         var inputArg = args[0];
         var patternArg = args[1];
 
-        // Only offer fix when pattern is a constant expression (literal, const field, etc.)
+        // Only offer the fix when the pattern is a constant expression: anything else would land
+        // in a field initializer that cannot reference locals/parameters and produce uncompilable code.
         var patternConstant = editor.SemanticModel.GetConstantValue(patternArg.Expression, token);
         if (!patternConstant.HasValue) return document;
 
-        // Build remaining args (skip input and pattern, e.g. RegexOptions, TimeSpan)
+        var containingType = invocation.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (containingType is null) return document;
+
+        var containingMember = invocation.FirstAncestorOrSelf<MemberDeclarationSyntax>(
+            n => n is MethodDeclarationSyntax or PropertyDeclarationSyntax or ConstructorDeclarationSyntax
+              or EventDeclarationSyntax or IndexerDeclarationSyntax or OperatorDeclarationSyntax
+              or ConversionOperatorDeclarationSyntax or DestructorDeclarationSyntax);
+        if (containingMember is null) return document;
+
+        // A static lambda / static local function inside an instance member still requires a static field.
+        bool isStaticContext = IsStaticContext(invocation, containingMember);
+
+        // Split remaining args between constructor (RegexOptions / TimeSpan) and instance call (others).
         var constructorExtraArgs = new SyntaxList<ArgumentSyntax>();
         var instanceExtraArgs = new SyntaxList<ArgumentSyntax>();
         for (int i = 2; i < args.Count; i++)
@@ -66,61 +77,91 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
                 instanceExtraArgs = instanceExtraArgs.Add(args[i].WithNameColon(null));
         }
 
-        // Find containing member (method, property, constructor, etc.) and containing type
-        var containingMember = invocation.FirstAncestorOrSelf<MemberDeclarationSyntax>(
-            n => n is MethodDeclarationSyntax or PropertyDeclarationSyntax or ConstructorDeclarationSyntax or EventDeclarationSyntax);
-        if (containingMember is null) return document;
+        string fieldName = GenerateUniqueFieldName(containingType);
 
-        var containingType = containingMember.FirstAncestorOrSelf<TypeDeclarationSyntax>();
-        if (containingType is null) return document;
+        // Build a fully-qualified Regex type expression annotated so Simplifier reduces it to `Regex`
+        // when a using is in scope and so an import is added otherwise. Each call returns a fresh node
+        // (a syntax node cannot have two parents).
+        SyntaxNode RegexTypeExpression() => editor.Generator
+            .TypeExpression(regexTypeSymbol)
+            .WithAdditionalAnnotations(Simplifier.AddImportsAnnotation);
 
-        // Determine if the containing member is static
-        bool isStaticContext = containingMember.Modifiers.Any(SyntaxKind.StaticKeyword);
+        var constructorArgs = new SyntaxList<ArgumentSyntax>()
+            .Add(SyntaxFactory.Argument(patternArg.Expression))
+            .AddRange(constructorExtraArgs);
 
-        // Build constructor arguments: pattern [, options] — preserve original expressions
-        var constructorArgs = new[] { SyntaxFactory.Argument(patternArg.Expression) }
-            .Concat(constructorExtraArgs.Select(a => a));
+        var objectCreation = SyntaxFactory.ObjectCreationExpression(
+            (TypeSyntax)RegexTypeExpression(),
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(constructorArgs)),
+            initializer: null);
 
-        // Build field modifiers: private [static] readonly
         var modifiers = isStaticContext
-            ? SyntaxFactory.TokenList(
-                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-                SyntaxFactory.Token(SyntaxKind.StaticKeyword),
-                SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
-            : SyntaxFactory.TokenList(
-                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-                SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
+            ? DeclarationModifiers.Static | DeclarationModifiers.ReadOnly
+            : DeclarationModifiers.ReadOnly;
 
-        // Create field: private [static] readonly Regex _regex = new Regex(pattern);
-        var fieldDeclaration = SyntaxFactory.FieldDeclaration(
-            SyntaxFactory.VariableDeclaration(
-                SyntaxFactory.IdentifierName("Regex"),
-                SyntaxFactory.SingletonSeparatedList(
-                    SyntaxFactory.VariableDeclarator("_regex")
-                        .WithInitializer(SyntaxFactory.EqualsValueClause(
-                            SyntaxFactory.ObjectCreationExpression(
-                                SyntaxFactory.IdentifierName("Regex"),
-                                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(constructorArgs)),
-                                null))))))
-            .WithModifiers(modifiers)
-            .NormalizeWhitespace()
-            .WithLeadingTrivia(containingMember.GetLeadingTrivia())
-            .WithTrailingTrivia(eol, eol);
+        var fieldDeclaration = ((FieldDeclarationSyntax)editor.Generator.FieldDeclaration(
+                fieldName,
+                RegexTypeExpression(),
+                Accessibility.Private,
+                modifiers,
+                objectCreation))
+            .WithAdditionalAnnotations(Formatter.Annotation);
 
-        // Replace invocation: _regex.IsMatch(input [, remaining]) — preserve original input arg
-        var instanceArgs = new[] { inputArg.WithNameColon(null) }
-            .Concat(instanceExtraArgs);
+        // Build the instance call: <fieldName>.<methodName>(input [, instanceExtras]).
+        var instanceArgs = new SyntaxList<ArgumentSyntax>()
+            .Add(inputArg.WithNameColon(null))
+            .AddRange(instanceExtraArgs);
 
         var newInvocation = SyntaxFactory.InvocationExpression(
             SyntaxFactory.MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
-                SyntaxFactory.IdentifierName("_regex"),
+                SyntaxFactory.IdentifierName(fieldName),
                 SyntaxFactory.IdentifierName(methodName)),
-            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(instanceArgs)));
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(instanceArgs)))
+            .WithTriviaFrom(invocation);
 
         editor.ReplaceNode(invocation, newInvocation);
         editor.InsertBefore(containingMember, fieldDeclaration);
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool IsStaticContext(SyntaxNode invocation, MemberDeclarationSyntax containingMember)
+    {
+        foreach (var ancestor in invocation.Ancestors())
+        {
+            if (ancestor == containingMember) break;
+            if (ancestor is LocalFunctionStatementSyntax lf && lf.Modifiers.Any(SyntaxKind.StaticKeyword)) return true;
+            if (ancestor is AnonymousFunctionExpressionSyntax af && af.Modifiers.Any(SyntaxKind.StaticKeyword)) return true;
+        }
+        return containingMember.Modifiers.Any(SyntaxKind.StaticKeyword);
+    }
+
+    private static string GenerateUniqueFieldName(TypeDeclarationSyntax containingType)
+    {
+        var existing = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var member in containingType.Members)
+        {
+            switch (member)
+            {
+                case FieldDeclarationSyntax field:
+                    foreach (var v in field.Declaration.Variables) existing.Add(v.Identifier.ValueText);
+                    break;
+                case EventFieldDeclarationSyntax eventField:
+                    foreach (var v in eventField.Declaration.Variables) existing.Add(v.Identifier.ValueText);
+                    break;
+                case PropertyDeclarationSyntax prop: existing.Add(prop.Identifier.ValueText); break;
+                case EventDeclarationSyntax ev: existing.Add(ev.Identifier.ValueText); break;
+                case MethodDeclarationSyntax method: existing.Add(method.Identifier.ValueText); break;
+            }
+        }
+
+        const string baseName = "_regex";
+        if (!existing.Contains(baseName)) return baseName;
+        for (int i = 1; ; i++)
+        {
+            var candidate = baseName + i;
+            if (!existing.Contains(candidate)) return candidate;
+        }
     }
 }

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs
@@ -50,27 +50,48 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
         var inputArg = args[0];
         var patternArg = args[1];
 
-        // Build remaining args (skip input and pattern, e.g. RegexOptions)
-        var remainingArgs = new SyntaxList<ArgumentSyntax>();
+        // Only offer fix when pattern is a constant expression (literal, const field, etc.)
+        var patternConstant = editor.SemanticModel.GetConstantValue(patternArg.Expression, token);
+        if (!patternConstant.HasValue) return document;
+
+        // Build remaining args (skip input and pattern, e.g. RegexOptions, TimeSpan)
         var constructorExtraArgs = new SyntaxList<ArgumentSyntax>();
+        var instanceExtraArgs = new SyntaxList<ArgumentSyntax>();
         for (int i = 2; i < args.Count; i++)
         {
             var argType = editor.SemanticModel.GetTypeInfo(args[i].Expression, token).Type;
-            if (argType is not null && argType.Name == "RegexOptions")
-                constructorExtraArgs = constructorExtraArgs.Add(args[i]);
+            if (argType is not null && (argType.Name == "RegexOptions" || argType.Name == "TimeSpan"))
+                constructorExtraArgs = constructorExtraArgs.Add(args[i].WithNameColon(null));
             else
-                remainingArgs = remainingArgs.Add(args[i]);
+                instanceExtraArgs = instanceExtraArgs.Add(args[i].WithNameColon(null));
         }
 
-        // Build constructor arguments: pattern [, options]
+        // Find containing member (method, property, constructor, etc.) and containing type
+        var containingMember = invocation.FirstAncestorOrSelf<MemberDeclarationSyntax>(
+            n => n is MethodDeclarationSyntax or PropertyDeclarationSyntax or ConstructorDeclarationSyntax or EventDeclarationSyntax);
+        if (containingMember is null) return document;
+
+        var containingType = containingMember.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (containingType is null) return document;
+
+        // Determine if the containing member is static
+        bool isStaticContext = containingMember.Modifiers.Any(SyntaxKind.StaticKeyword);
+
+        // Build constructor arguments: pattern [, options] — preserve original expressions
         var constructorArgs = new[] { SyntaxFactory.Argument(patternArg.Expression) }
-            .Concat(constructorExtraArgs.Select(a => SyntaxFactory.Argument(a.Expression)));
+            .Concat(constructorExtraArgs.Select(a => a));
 
-        // Find containing method for indentation and insertion point
-        var containingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod is null) return document;
+        // Build field modifiers: private [static] readonly
+        var modifiers = isStaticContext
+            ? SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+                SyntaxFactory.Token(SyntaxKind.StaticKeyword),
+                SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
+            : SyntaxFactory.TokenList(
+                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+                SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
 
-        // Create field: private readonly Regex _regex = new Regex(pattern);
+        // Create field: private [static] readonly Regex _regex = new Regex(pattern);
         var fieldDeclaration = SyntaxFactory.FieldDeclaration(
             SyntaxFactory.VariableDeclaration(
                 SyntaxFactory.IdentifierName("Regex"),
@@ -81,16 +102,14 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
                                 SyntaxFactory.IdentifierName("Regex"),
                                 SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(constructorArgs)),
                                 null))))))
-            .WithModifiers(SyntaxFactory.TokenList(
-                SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-                SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)))
+            .WithModifiers(modifiers)
             .NormalizeWhitespace()
-            .WithLeadingTrivia(containingMethod.GetLeadingTrivia())
+            .WithLeadingTrivia(containingMember.GetLeadingTrivia())
             .WithTrailingTrivia(eol, eol);
 
-        // Replace invocation: _regex.IsMatch(input [, remaining])
-        var instanceArgs = new[] { SyntaxFactory.Argument(inputArg.Expression) }
-            .Concat(remainingArgs.Select(a => SyntaxFactory.Argument(a.Expression)));
+        // Replace invocation: _regex.IsMatch(input [, remaining]) — preserve original input arg
+        var instanceArgs = new[] { inputArg.WithNameColon(null) }
+            .Concat(instanceExtraArgs);
 
         var newInvocation = SyntaxFactory.InvocationExpression(
             SyntaxFactory.MemberAccessExpression(
@@ -100,7 +119,7 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodFixer : CodeFixProvider
             SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(instanceArgs)));
 
         editor.ReplaceNode(invocation, newInvocation);
-        editor.InsertBefore(containingMethod, fieldDeclaration);
+        editor.InsertBefore(containingMember, fieldDeclaration);
 
         return editor.GetChangedDocument();
     }

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.cs
@@ -33,21 +33,25 @@ public sealed class UseRegexInstanceInsteadOfStaticMethod : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(static context => AnalyzeInvocation(context), Invocation);
+        context.RegisterCompilationStartAction(static startContext =>
+        {
+            var regexType = startContext.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Regex");
+            if (regexType is null) return;
+
+            startContext.RegisterOperationAction(
+                operationContext => AnalyzeInvocation(operationContext, regexType),
+                Invocation);
+        });
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol regexType)
     {
         if (context.Operation is not IInvocationOperation operation) return;
 
         var method = operation.TargetMethod;
-        if (!method.IsStatic) return;
-
-        var regexType = context.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Regex");
-        if (regexType is null) return;
-
-        if (!SymbolEqualityComparer.Default.Equals(method.ContainingType, regexType)) return;
         if (!StaticRegexMethods.Contains(method.Name)) return;
+        if (!method.IsStatic) return;
+        if (!SymbolEqualityComparer.Default.Equals(method.ContainingType, regexType)) return;
 
         context.ReportDiagnostic(Diagnostic.Create(Descriptor, operation.Syntax.GetLocation()));
     }

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.cs
@@ -10,10 +10,10 @@ public sealed class UseRegexInstanceInsteadOfStaticMethod : DiagnosticAnalyzer
     public static DiagnosticDescriptor Descriptor { get; } = Rule.CreateDescriptor(
         id: Rule.Ids.GCI97_UseRegexInstanceInsteadOfStaticMethod,
         title: "Use Regex instance instead of static method",
-        message: "Use a Regex instance instead of a static method to avoid recompiling the pattern each time",
+        message: "Use a Regex instance instead of a static method to avoid repeated pattern parsing overhead",
         category: Rule.Categories.Performance,
         severity: DiagnosticSeverity.Warning,
-        description: "Static Regex methods recompile the pattern on each call. Using a cached Regex instance avoids this overhead and reduces CPU and energy consumption.");
+        description: "Static Regex methods rely on a limited internal cache and incur pattern parsing overhead. Using an explicitly cached Regex instance makes caching deterministic and reduces CPU and energy consumption.");
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;

--- a/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.cs
+++ b/src/Creedengo.Core/Analyzers/GCI97.UseRegexInstanceInsteadOfStaticMethod.cs
@@ -1,0 +1,54 @@
+namespace Creedengo.Core.Analyzers;
+
+/// <summary>GCI97: Use Regex instance instead of static method.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseRegexInstanceInsteadOfStaticMethod : DiagnosticAnalyzer
+{
+    private static readonly ImmutableArray<OperationKind> Invocation = ImmutableArray.Create(OperationKind.Invocation);
+
+    /// <summary>The diagnostic descriptor.</summary>
+    public static DiagnosticDescriptor Descriptor { get; } = Rule.CreateDescriptor(
+        id: Rule.Ids.GCI97_UseRegexInstanceInsteadOfStaticMethod,
+        title: "Use Regex instance instead of static method",
+        message: "Use a Regex instance instead of a static method to avoid recompiling the pattern each time",
+        category: Rule.Categories.Performance,
+        severity: DiagnosticSeverity.Warning,
+        description: "Static Regex methods recompile the pattern on each call. Using a cached Regex instance avoids this overhead and reduces CPU and energy consumption.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
+    private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics = ImmutableArray.Create(Descriptor);
+
+    private static readonly HashSet<string> StaticRegexMethods = new(StringComparer.Ordinal)
+    {
+        nameof(System.Text.RegularExpressions.Regex.IsMatch),
+        nameof(System.Text.RegularExpressions.Regex.Match),
+        nameof(System.Text.RegularExpressions.Regex.Matches),
+        nameof(System.Text.RegularExpressions.Regex.Replace),
+        nameof(System.Text.RegularExpressions.Regex.Split),
+    };
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterOperationAction(static context => AnalyzeInvocation(context), Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        if (context.Operation is not IInvocationOperation operation) return;
+
+        var method = operation.TargetMethod;
+        if (!method.IsStatic) return;
+
+        var regexType = context.Compilation.GetTypeByMetadataName("System.Text.RegularExpressions.Regex");
+        if (regexType is null) return;
+
+        if (!SymbolEqualityComparer.Default.Equals(method.ContainingType, regexType)) return;
+        if (!StaticRegexMethods.Contains(method.Name)) return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor, operation.Syntax.GetLocation()));
+    }
+}

--- a/src/Creedengo.Core/Models/Rule.cs
+++ b/src/Creedengo.Core/Models/Rule.cs
@@ -31,6 +31,7 @@ internal static class Rule
         public const string GCI95_UseIsOperatorInsteadOfAsOperator = "GCI95";
         public const string GCIXX_UnnecessaryAssignment = "GCIXX";
         public const string GCI96_UseEventArgsDotEmpty = "GCI96";
+        public const string GCI97_UseRegexInstanceInsteadOfStaticMethod = "GCI97";
     }
 
     /// <summary>Creates a diagnostic descriptor.</summary>

--- a/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
+++ b/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
@@ -45,7 +45,7 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
         """);
 
     [TestMethod]
-    public Task StaticRegexMatchShouldReportAsync() => VerifyAsync("""
+    public Task StaticRegexMatchShouldReportAndFixAsync() => VerifyAsync("""
         using System.Text.RegularExpressions;
         public class Test
         {
@@ -54,10 +54,21 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
                 var m = [|Regex.Match("abc", @"\w")|];
             }
         }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+
+            public void Run()
+            {
+                var m = _regex.Match("abc");
+            }
+        }
         """);
 
     [TestMethod]
-    public Task StaticRegexReplaceShouldReportAsync() => VerifyAsync("""
+    public Task StaticRegexReplaceShouldReportAndFixAsync() => VerifyAsync("""
         using System.Text.RegularExpressions;
         public class Test
         {
@@ -66,10 +77,21 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
                 string r = [|Regex.Replace("abc", @"\w", "x")|];
             }
         }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+
+            public void Run()
+            {
+                string r = _regex.Replace("abc", "x");
+            }
+        }
         """);
 
     [TestMethod]
-    public Task StaticRegexSplitShouldReportAsync() => VerifyAsync("""
+    public Task StaticRegexSplitShouldReportAndFixAsync() => VerifyAsync("""
         using System.Text.RegularExpressions;
         public class Test
         {
@@ -78,16 +100,38 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
                 string[] r = [|Regex.Split("abc", @"\w")|];
             }
         }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+
+            public void Run()
+            {
+                string[] r = _regex.Split("abc");
+            }
+        }
         """);
 
     [TestMethod]
-    public Task StaticRegexMatchesShouldReportAsync() => VerifyAsync("""
+    public Task StaticRegexMatchesShouldReportAndFixAsync() => VerifyAsync("""
         using System.Text.RegularExpressions;
         public class Test
         {
             public void Run()
             {
                 var r = [|Regex.Matches("abc", @"\w")|];
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+
+            public void Run()
+            {
+                var r = _regex.Matches("abc");
             }
         }
         """);
@@ -140,6 +184,29 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
             public void Run(string pattern)
             {
                 bool isMatch = [|Regex.IsMatch("abc", pattern)|];
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexWithOptionsShouldReportAndFixAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                bool isMatch = [|Regex.IsMatch("abc", @"\w", RegexOptions.IgnoreCase)|];
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w", RegexOptions.IgnoreCase);
+
+            public void Run()
+            {
+                bool isMatch = _regex.IsMatch("abc");
             }
         }
         """);

--- a/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
+++ b/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
@@ -91,4 +91,81 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
             }
         }
         """);
+
+    [TestMethod]
+    public Task StaticRegexInStaticMethodShouldReportWithStaticFieldAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public static void Run()
+            {
+                bool isMatch = [|Regex.IsMatch("abc", @"\w")|];
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private static readonly Regex _regex = new Regex(@"\w");
+
+            public static void Run()
+            {
+                bool isMatch = _regex.IsMatch("abc");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexInPropertyShouldReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public bool IsValid => [|Regex.IsMatch("abc", @"\w")|];
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+
+            public bool IsValid => _regex.IsMatch("abc");
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexWithNonConstantPatternShouldReportButNotFixAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run(string pattern)
+            {
+                bool isMatch = [|Regex.IsMatch("abc", pattern)|];
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexWithTimeoutShouldReportAndFixAsync() => VerifyAsync("""
+        using System;
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                bool isMatch = [|Regex.IsMatch("abc", @"\w", RegexOptions.None, TimeSpan.FromSeconds(1))|];
+            }
+        }
+        """, """
+        using System;
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+            public void Run()
+            {
+                bool isMatch = _regex.IsMatch("abc");
+            }
+        }
+        """);
 }

--- a/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
+++ b/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
@@ -235,4 +235,77 @@ public sealed class UseRegexInstanceInsteadOfStaticMethodTests
             }
         }
         """);
+
+    [TestMethod]
+    public Task FullyQualifiedStaticRegexWithoutUsingShouldReportAndFixAsync() => VerifyAsync("""
+        public class Test
+        {
+            public void Run()
+            {
+                bool isMatch = [|System.Text.RegularExpressions.Regex.IsMatch("abc", @"\w")|];
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+
+            public void Run()
+            {
+                bool isMatch = _regex.IsMatch("abc");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexInStaticLocalFunctionShouldUseStaticFieldAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                static bool Check() => [|Regex.IsMatch("abc", @"\w")|];
+                _ = Check();
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private static readonly Regex _regex = new Regex(@"\w");
+
+            public void Run()
+            {
+                static bool Check() => _regex.IsMatch("abc");
+                _ = Check();
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexWhenRegexFieldAlreadyExistsShouldUseUniqueNameAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\d");
+            public void Run()
+            {
+                bool isMatch = [|Regex.IsMatch("abc", @"\w")|];
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\d");
+            private readonly Regex _regex1 = new Regex(@"\w");
+
+            public void Run()
+            {
+                bool isMatch = _regex1.IsMatch("abc");
+            }
+        }
+        """);
 }

--- a/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
+++ b/src/Creedengo.Tests/Tests/GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs
@@ -1,0 +1,94 @@
+namespace Creedengo.Tests.Tests;
+
+[TestClass]
+public sealed class UseRegexInstanceInsteadOfStaticMethodTests
+{
+    private static readonly CodeFixerDlg VerifyAsync = TestRunner.VerifyAsync<UseRegexInstanceInsteadOfStaticMethod, UseRegexInstanceInsteadOfStaticMethodFixer>;
+
+    [TestMethod]
+    public Task EmptyCodeAsync() => VerifyAsync("");
+
+    [TestMethod]
+    public Task RegexInstanceCallShouldNotReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+            public void Run()
+            {
+                bool isMatch = _regex.IsMatch("abc");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexIsMatchShouldReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                bool isMatch = [|Regex.IsMatch("abc", @"\w")|];
+            }
+        }
+        """, """
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            private readonly Regex _regex = new Regex(@"\w");
+        
+            public void Run()
+            {
+                bool isMatch = _regex.IsMatch("abc");
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexMatchShouldReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                var m = [|Regex.Match("abc", @"\w")|];
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexReplaceShouldReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                string r = [|Regex.Replace("abc", @"\w", "x")|];
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexSplitShouldReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                string[] r = [|Regex.Split("abc", @"\w")|];
+            }
+        }
+        """);
+
+    [TestMethod]
+    public Task StaticRegexMatchesShouldReportAsync() => VerifyAsync("""
+        using System.Text.RegularExpressions;
+        public class Test
+        {
+            public void Run()
+            {
+                var r = [|Regex.Matches("abc", @"\w")|];
+            }
+        }
+        """);
+}


### PR DESCRIPTION
Étape Statut
✅ Pas couvert par CAxxxx / SYSLIB1xxx SYSLIB1045 concerne GeneratedRegex (.NET 7+), pas le même cas ✅ Pertinence green-coding Les méthodes statiques Regex recompilent le pattern à chaque appel → CPU/énergie gaspillés ✅ ID choisi GCI97
✅ Analyzer GCI97.UseRegexInstanceInsteadOfStaticMethod.cs — détecte Regex.IsMatch, Match, Matches, Replace, Split statiques ✅ Code Fixer GCI97.UseRegexInstanceInsteadOfStaticMethod.Fixer.cs — extrait le pattern, crée un champ private readonly Regex _regex, remplace l'appel statique par un appel d'instance ✅ Tests (7/7 pass) GCI97.UseRegexInstanceInsteadOfStaticMethod.Tests.cs ✅ Docs README.md mis à jour
✅ Exemple GCI007.AvoidUsingInstanceRegex.cs mis à jour avec le code corrigé